### PR TITLE
Inclusivity Resources for 'Just CS'

### DIFF
--- a/justcs.md
+++ b/justcs.md
@@ -46,6 +46,7 @@ this list.__ Pull requests are welcome.
   [activism](https://github.com/drewrwilson/toolsforactivism)
 * [EFF.org projects](https://github.com/EFForg)
 
+
 #### Race
 
 * [CMD-IT](https://cmd-it.org/)
@@ -73,6 +74,10 @@ this list.__ Pull requests are welcome.
 * [LGBTQ in Technology](https://lgbtq.technology/) Slack space
 * [Out in Tech](https://outintech.com/) Organization
 * [Lesbians Who Tech](https://lesbianswhotech.org/)
+
+#### Inclusivity
+
+* [Inclusive Naming Initiative](https://inclusivenaming.org/)
 
 ### Fairness & Privacy
 

--- a/justcs.md
+++ b/justcs.md
@@ -46,7 +46,6 @@ this list.__ Pull requests are welcome.
   [activism](https://github.com/drewrwilson/toolsforactivism)
 * [EFF.org projects](https://github.com/EFForg)
 
-
 #### Race
 
 * [CMD-IT](https://cmd-it.org/)
@@ -78,6 +77,7 @@ this list.__ Pull requests are welcome.
 #### Inclusivity
 
 * [Inclusive Naming Initiative](https://inclusivenaming.org/)
+* [Atlassian Design System: Inclusive Language](https://atlassian.design/content/inclusive-writing)
 
 ### Fairness & Privacy
 


### PR DESCRIPTION
This is an awesome list. Thanks for collecting these resources!

Being intentional about naming decisions and the copy we write into software products, as well as the language we use as developers, is something that's been on my mind recently. A colleague and I are working on socializing these topics among our teams at @rescale and I thought I'd share a few pages we've found. The [Inclusive Naming Initiative](https://inclusivenaming.org/) is a nice entry point to reading more about making software welcoming to all. Atlassian also has a growing reference.